### PR TITLE
Add support for specifying config file via -f parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Usage
      -d <device>
      -D <timestamp>
      -e <expire>
+     -f <config file>
      -p <priority>
      -r <retry>
      -t <title>
@@ -30,7 +31,7 @@ Usage
      -u <url>
      -U <USER> (required if not in config file)
 
-To use this script, you must have TOKEN and USER (or GROUP) keys from [PushOver][1]. These may then be specified on the terminal with `-T` and `-U`, or you may store default values for both in `${HOME}/.config/pushover.conf`. If you need to override this path, such as for multiple accounts, use the environment variable PUSHOVER_CONFIG with the full path to the desired config file.
+To use this script, you must have TOKEN and USER (or GROUP) keys from [PushOver][1]. These may then be specified on the terminal with `-T` and `-U`, or you may store default values for both in `${HOME}/.config/pushover.conf`. If you need to override this path, such as for multiple accounts, either specify the config file as a parameter using `-f` or use the environment variable PUSHOVER_CONFIG with the full path to the desired config file.
 
 Config file format
 ==================

--- a/pushover.sh
+++ b/pushover.sh
@@ -13,20 +13,6 @@ else
     declare -A device_aliases=()
 fi
 
-# Load user config
-read_config() {
-    if [ ! -z "${config}" ]; then
-        CONFIG_FILE="${config}"
-    elif [ ! -z "${PUSHOVER_CONFIG}" ]; then
-        CONFIG_FILE="${PUSHOVER_CONFIG}"
-    else
-        CONFIG_FILE="${XDG_CONFIG_HOME-${HOME}/.config}/pushover.conf"
-    fi
-    if [ -e "${CONFIG_FILE}" ]; then
-        . "${CONFIG_FILE}"
-    fi
-}
-
 # Functions used elsewhere in this script
 usage() {
     echo "${0} <options> <message>"
@@ -126,13 +112,21 @@ devices="${devices} ${device}"
 optstring="c:d:D:e:f:p:r:t:T:s:u:U:a:h"
 while getopts ${optstring} c; do
     case ${c} in
-        f) config="${OPTARG}" ;;
+        f) PUSHOVER_CONFIG="${OPTARG}" ;;
     esac
 done
 
-# Read configuration so that overrides can take precedence
-read_config
+# Load user config
+if [ ! -z "${PUSHOVER_CONFIG}" ]; then
+    CONFIG_FILE="${PUSHOVER_CONFIG}"
+else
+    CONFIG_FILE="${XDG_CONFIG_HOME-${HOME}/.config}/pushover.conf"
+fi
+if [ -e "${CONFIG_FILE}" ]; then
+    . "${CONFIG_FILE}"
+fi
 
+# Process the remaining options
 OPTIND=1
 while getopts ${optstring} c; do
     case ${c} in


### PR DESCRIPTION
Add support specifying a (single) config file via the -f parameter. If both a config file and command-line options are specified, the command-line parameters override the config file. This closes #16.