### PR TITLE
use /usr/bin/env for making it more compatible

### DIFF
--- a/pushover.sh
+++ b/pushover.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Default config vars
 CURL="$(which curl)"


### PR DESCRIPTION
When using /usr/bin/env bash you do not rely on having bash in /bin which is for example the case with freebsd where it is located at /usr/local/bin/bash